### PR TITLE
Add command line argument "--no-console" to Hide ProcessConsoleFrame.

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/Launcher.java
+++ b/launcher/src/main/java/com/skcraft/launcher/Launcher.java
@@ -60,7 +60,7 @@ public final class Launcher {
     @Getter private final Configuration config;
     @Getter private final AccountList accounts;
     @Getter private final AssetsRoot assets;
-    @Getter private final LaunchSupervisor launchSupervisor = new LaunchSupervisor(this);
+    @Getter private final LaunchSupervisor launchSupervisor;
     @Getter private final UpdateManager updateManager = new UpdateManager(this);
     @Getter private final InstanceTasks instanceTasks = new InstanceTasks(this);
 
@@ -70,7 +70,7 @@ public final class Launcher {
      * @param baseDir the base directory
      * @throws java.io.IOException on load error
      */
-    public Launcher(@NonNull File baseDir) throws IOException {
+    public Launcher(@NonNull File baseDir, boolean showProcessConsole) throws IOException {
         SharedLocale.loadBundle("com.skcraft.launcher.lang.Launcher", Locale.getDefault());
 
         this.baseDir = baseDir;
@@ -78,6 +78,7 @@ public final class Launcher {
                 "launcher.properties", "com.skcraft.launcher.propertiesFile");
         this.instances = new InstanceList(this);
         this.assets = new AssetsRoot(new File(baseDir, "assets"));
+        this.launchSupervisor = new LaunchSupervisor(this, showProcessConsole);
         this.config = Persistence.load(new File(baseDir, "config.json"), Configuration.class);
         this.accounts = Persistence.load(new File(baseDir, "accounts.dat"), AccountList.class);
 
@@ -376,7 +377,7 @@ public final class Launcher {
             log.info("Using current directory " + dir.getAbsolutePath());
         }
 
-        return new Launcher(dir);
+        return new Launcher(dir, !options.isNoConsole());
     }
 
     /**

--- a/launcher/src/main/java/com/skcraft/launcher/LauncherArguments.java
+++ b/launcher/src/main/java/com/skcraft/launcher/LauncherArguments.java
@@ -26,4 +26,7 @@ public class LauncherArguments {
     @Parameter(names = "--portable")
     private boolean portable;
 
+    @Parameter(names = "--no-console", description = "Hides the concole for the started Minecraft process.")
+    private boolean noConsole;
+
 }

--- a/launcher/src/main/java/com/skcraft/launcher/launch/IProcessOutputConsumer.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/IProcessOutputConsumer.java
@@ -1,0 +1,16 @@
+package com.skcraft.launcher.launch;
+
+import java.io.InputStream;
+
+/**
+ * Created by octavian on 26.04.15.
+ */
+public interface IProcessOutputConsumer {
+    /**
+     * Consume an input stream and print it to the dialog. The consumer
+     * will be in a separate daemon thread.
+     *
+     * @param from stream to read
+     */
+    public void consume(InputStream from);
+}

--- a/launcher/src/main/java/com/skcraft/launcher/launch/LaunchProcessHandler.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/LaunchProcessHandler.java
@@ -8,9 +8,7 @@ package com.skcraft.launcher.launch;
 
 import com.google.common.base.Function;
 import com.skcraft.launcher.Launcher;
-import com.skcraft.launcher.dialog.LauncherFrame;
 import com.skcraft.launcher.dialog.ProcessConsoleFrame;
-import com.skcraft.launcher.swing.MessageLog;
 import lombok.NonNull;
 import lombok.extern.java.Log;
 
@@ -27,10 +25,12 @@ public class LaunchProcessHandler implements Function<Process, ProcessConsoleFra
     private static final int CONSOLE_NUM_LINES = 10000;
 
     private final Launcher launcher;
+    private final boolean showProcessConsole;
     private ProcessConsoleFrame consoleFrame;
 
-    public LaunchProcessHandler(@NonNull Launcher launcher) {
+    public LaunchProcessHandler(@NonNull Launcher launcher, boolean showProcessConsole) {
         this.launcher = launcher;
+        this.showProcessConsole = showProcessConsole;
     }
 
     @Override
@@ -41,10 +41,15 @@ public class LaunchProcessHandler implements Function<Process, ProcessConsoleFra
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override
                 public void run() {
-                    consoleFrame = new ProcessConsoleFrame(CONSOLE_NUM_LINES, true);
-                    consoleFrame.setProcess(process);
-                    consoleFrame.setVisible(true);
-                    MessageLog messageLog = consoleFrame.getMessageLog();
+                    IProcessOutputConsumer messageLog;
+                    if (showProcessConsole) {
+                        consoleFrame = new ProcessConsoleFrame(CONSOLE_NUM_LINES, true);
+                        consoleFrame.setProcess(process);
+                        consoleFrame.setVisible(true);
+                        messageLog = consoleFrame.getMessageLog();
+                    } else {
+                        messageLog = new ProcessOutputConsumerPassThrough();
+                    }
                     messageLog.consume(process.getInputStream());
                     messageLog.consume(process.getErrorStream());
                 }

--- a/launcher/src/main/java/com/skcraft/launcher/launch/LaunchSupervisor.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/LaunchSupervisor.java
@@ -37,9 +37,11 @@ import static com.skcraft.launcher.util.SharedLocale.tr;
 public class LaunchSupervisor {
 
     private final Launcher launcher;
+    private final boolean showProcessConsole;
 
-    public LaunchSupervisor(Launcher launcher) {
+    public LaunchSupervisor(Launcher launcher, boolean showProcessConsole) {
         this.launcher = launcher;
+        this.showProcessConsole = showProcessConsole;
     }
 
     public void launch(final Window window, final Instance instance, boolean permitUpdate, final LaunchListener listener) {
@@ -136,7 +138,7 @@ public class LaunchSupervisor {
 
         // Watch the created process
         ListenableFuture<?> future = Futures.transform(
-                processFuture, new LaunchProcessHandler(launcher), launcher.getExecutor());
+                processFuture, new LaunchProcessHandler(launcher, showProcessConsole), launcher.getExecutor());
         SwingHelper.addErrorDialogCallback(null, future);
 
         // Clean up at the very end

--- a/launcher/src/main/java/com/skcraft/launcher/launch/ProcessOutputConsumerPassThrough.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/ProcessOutputConsumerPassThrough.java
@@ -1,0 +1,45 @@
+/*
+ * SK's Minecraft Launcher
+ * Copyright (C) 2010-2014 Albert Pham <http://www.sk89q.com> and contributors
+ * Please see LICENSE.txt for license information.
+ */
+
+package com.skcraft.launcher.launch;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
+/**
+ * A simple process output consumer which will pass everything it consumes to System.out.
+ */
+public class ProcessOutputConsumerPassThrough implements IProcessOutputConsumer {
+    /**
+     * Consume an input stream and print it to the dialog. The consumer
+     * will be in a separate daemon thread.
+     *
+     * @param from stream to read
+     */
+    public void consume(InputStream from) {
+        final InputStream in = from;
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                byte[] buffer = new byte[1024];
+                try {
+                    int len;
+                    while ((len = in.read(buffer)) != -1) {
+                        String s = new String(buffer, 0, len);
+                        System.out.print(s);
+                    }
+                } catch (IOException e) {
+                } finally {
+                    closeQuietly(in);
+                }
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
+    }
+}

--- a/launcher/src/main/java/com/skcraft/launcher/swing/MessageLog.java
+++ b/launcher/src/main/java/com/skcraft/launcher/swing/MessageLog.java
@@ -6,7 +6,7 @@
 
 package com.skcraft.launcher.swing;
 
-import com.skcraft.launcher.LauncherUtils;
+import com.skcraft.launcher.launch.IProcessOutputConsumer;
 import com.skcraft.launcher.util.LimitLinesDocumentListener;
 import com.skcraft.launcher.util.SimpleLogFormatter;
 
@@ -27,7 +27,7 @@ import static org.apache.commons.io.IOUtils.closeQuietly;
 /**
  * A simple message log.
  */
-public class MessageLog extends JPanel {
+public class MessageLog extends JPanel implements IProcessOutputConsumer {
 
     private static final Logger rootLogger = Logger.getLogger("");
     


### PR DESCRIPTION
--no-console will prevent the creation of a Minecraft output console. ProcessOutputConsumerPassThrough is used instead. This class passes every input to System.out.